### PR TITLE
Making cg-gas generator work out-of-box

### DIFF
--- a/app/templates/skeleton/app/app.js
+++ b/app/templates/skeleton/app/app.js
@@ -1,4 +1,4 @@
-angular.module('<%= _.camelize(appname) %>', ['ui.bootstrap','ui.utils','<%= routerModuleName %>','ngAnimate'/**template-holder**/]);
+angular.module('<%= _.camelize(appname) %>', ['ui.bootstrap','ui.utils','<%= routerModuleName %>','ngAnimate']);
 <% if (!uirouter) { %>
 angular.module('<%= _.camelize(appname) %>').config(function($routeProvider) {
 

--- a/app/templates/skeleton/app/app.js
+++ b/app/templates/skeleton/app/app.js
@@ -18,7 +18,7 @@ angular.module('<%= _.camelize(appname) %>').config(function($stateProvider, $ur
 
 });
 <% } %>
-angular.module('<%= _.camelize(appname) %>').run(function($rootScope,<% if(uirouter) { print('$state,$stateParams'); } else { print(''); } %>) {
+angular.module('<%= _.camelize(appname) %>').run(function($rootScope<% if(uirouter) { print(',$state,$stateParams'); } else { print(''); } %>) {
 
    <% if(uirouter) { print('$rootScope.$state=$state;\n$rootScope.$stateParams=$stateParams;'); } else { print(''); } %>
 

--- a/app/templates/skeleton/app/app.js
+++ b/app/templates/skeleton/app/app.js
@@ -1,4 +1,4 @@
-angular.module('<%= _.camelize(appname) %>', ['ui.bootstrap','ui.utils','<%= routerModuleName %>','ngAnimate','templates']);
+angular.module('<%= _.camelize(appname) %>', ['ui.bootstrap','ui.utils','<%= routerModuleName %>','ngAnimate'/**template-holder**/]);
 <% if (!uirouter) { %>
 angular.module('<%= _.camelize(appname) %>').config(function($routeProvider) {
 
@@ -18,7 +18,10 @@ angular.module('<%= _.camelize(appname) %>').config(function($stateProvider, $ur
 
 });
 <% } %>
-angular.module('<%= _.camelize(appname) %>').run(function($rootScope) {
+angular.module('<%= _.camelize(appname) %>').run(function($rootScope,<% if(uirouter) { print('$state,$stateParams'); } else { print(''); } %>) {
+
+   <% if(uirouter) { print('$rootScope.$state=$state;\n$rootScope.$stateParams=$stateParams;'); } else { print(''); } %>
+
 
     $rootScope.safeApply = function(fn) {
         var phase = $rootScope.$$phase;

--- a/app/templates/skeleton/app/index.html
+++ b/app/templates/skeleton/app/index.html
@@ -4,10 +4,10 @@
   <title></title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta charset="utf-8">
-  
+
   <title><%= appname %></title>
   <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
-  
+
   <!-- build:css styles/vendor.css -->
   <!-- bower:css -->
   <!-- endbower -->
@@ -35,17 +35,17 @@
   <!-- endbower -->
   <!-- endbuild -->
 
+  <!-- template-holder -->
 
  <!-- build:js scripts/app.js -->
  <!-- Main App JS -->
  <script src="app.js"></script>
- <script src="tmp/templates.js"></script>
- <!-- Add New Component JS Above -->       
-        
+ <!-- Add New Component JS Above -->
+
  <!-- endbuild -->
 
 
-  
+
 
 </body>
 </html>

--- a/app/templates/skeleton/build/build.config.js
+++ b/app/templates/skeleton/build/build.config.js
@@ -3,17 +3,21 @@
 //basic configuration object used by gulp tasks
 module.exports = {
   port: 3000,
-  tmp: 'build/tmp',
+  html: 'app/**/*.html',
+  tmpDist: 'build/dist/scripts',
+  sassDist: 'build/tmp',
   dist: 'build/dist',
   base: 'app',
-  tpl: 'app/modules/**/*.html',   
-  mainScss: 'app/app.scss', 
-  scss: 'app/**/*.scss', 
+  tpl: ['!app/index.html',
+  '!app/vendor/**/*.html',
+  '!app/test/**/*.html',
+  'app/**/*.html'],
+  mainScss: 'app/app.scss',
+  scss: 'app/**/*.scss',
   js: [
-    'app/modules/**/*.js',
     '!app/vendor/**/*.js',
-    'app/**/*-spec.js',   //unit
-    'app/test/e2e/**/*.js'  //e2e
+    '!app/test/unit-results/**/*.js',
+    'app/**/.js',   //unit
   ],
   index: 'app/index.html',
   assets: 'app/assets/**',

--- a/app/templates/skeleton/build/build.config.js
+++ b/app/templates/skeleton/build/build.config.js
@@ -17,7 +17,7 @@ module.exports = {
   js: [
     '!app/vendor/**/*.js',
     '!app/test/unit-results/**/*.js',
-    'app/**/.js',   //unit
+    'app/**/*.js',   //unit
   ],
   index: 'app/index.html',
   assets: 'app/assets/**',

--- a/app/templates/skeleton/build/karma.config.js
+++ b/app/templates/skeleton/build/karma.config.js
@@ -20,9 +20,11 @@ module.exports = {
     baseDir + '/vendor/angular-bootstrap/ui-bootstrap-tpls.js',
     baseDir + '/vendor/moment/moment.js',
     baseDir + '/vendor/**/*min.js',
+    baseDir + '/app.js',
     baseDir + '/modules/**/*.js',
+    baseDir + '/service/**/*.js',
+    baseDir + '/partial/**/*.js',
     'build/tmp/*.js',
-    baseDir + '/modules/**/*-spec.js'
   ],
 
   //used framework

--- a/app/templates/skeleton/gulpfile.js
+++ b/app/templates/skeleton/gulpfile.js
@@ -239,7 +239,7 @@ gulp.task('serve', ['build'], function() {
   gulp.watch(config.html, reload);
   gulp.watch(config.scss, ['sass', reload]);
   gulp.watch(config.js, ['jshint']);
-  gulp.watch(config.tpl, ['templates', reload]);
+  gulp.watch(config.js, reload);
   gulp.watch(config.assets, reload);
 });
 

--- a/app/templates/skeleton/gulpfile.js
+++ b/app/templates/skeleton/gulpfile.js
@@ -1,6 +1,7 @@
 //'use strict';
 // generated on <%= (new Date).toISOString().split('T')[0] %> using <%= pkg.name %> <%= pkg.version %>
 
+var appConfig = require('./package.json');
 var config = require('./build/build.config.js');
 var karmaConfig = require('./build/karma.config.js');
 var protractorConfig = require('./build/protractor.config.js');
@@ -115,7 +116,7 @@ gulp.task('html', function() {
   .pipe($.replace('<!-- template-holder -->','<script src="scripts/templates.js"></script>'))
   .pipe(assets)
   .pipe($.sourcemaps.init())
-  .pipe($.if('**/*app.js',$.replace('/**template-holder**/',',"templates"')))
+  .pipe($.if('**/*app.js',$.replace(new RegExp(appConfig.name+'\\u0027\\s*,\\s*\\u005b','i'),appConfig.name+'\', ["templates",')))
   .pipe($.if('**/*.js', $.ngAnnotate()))
   .pipe($.if('**/*.js', $.uglify({
     mangle: false,

--- a/app/templates/skeleton/package.json
+++ b/app/templates/skeleton/package.json
@@ -21,6 +21,7 @@
     "gulp-ng-annotate": "^0.3.3",
     "gulp-ng-html2js": "^0.1.8",
     "gulp-protractor": "0.0.11",
+    "gulp-replace": "^0.5.0",
     "gulp-rev": "^2.0.1",
     "gulp-rev-replace": "^0.3.1",
     "gulp-ruby-sass": "^0.7.1",

--- a/partial/index.js
+++ b/partial/index.js
@@ -35,7 +35,7 @@ PartialGenerator.prototype.askFor = function askFor() {
             cgUtils.askForModuleAndDir('partial',this,true,cb);
         }.bind(this));
     }else{
-        if(this.options.partialoptions.route!==undefined) 
+        if(this.options.partialoptions.route!==undefined)
             this.route = this.options.partialoptions.route;
 
         cgUtils.askForModuleAndDir('partial',this,true,cb);
@@ -49,7 +49,7 @@ PartialGenerator.prototype.files = function files() {
     cgUtils.processTemplates(this.name,this.dir,'partial',this,null,null,this.module);
 
     if (this.route && this.route.length > 0){
-        var partialUrl = this.dir + "/"+ this.name + '.html';
+        var partialUrl = this.dir + this.name + '.html';
         partialUrl=partialUrl.replace("app/","");
         cgUtils.injectRoute(this.module.file,this.config.get('uirouter'),this.name,this.route,partialUrl,this);
     }

--- a/partial/index.js
+++ b/partial/index.js
@@ -50,7 +50,9 @@ PartialGenerator.prototype.files = function files() {
 
     if (this.route && this.route.length > 0){
         var partialUrl = this.dir + this.name + '.html';
-        partialUrl=partialUrl.replace("app/","");
+        //fixed for both slashes windows or unix style directory divider
+        partialUrl=partialUrl.substr(4);
+        console.log("url after replace "+partialUrl);
         cgUtils.injectRoute(this.module.file,this.config.get('uirouter'),this.name,this.route,partialUrl,this);
     }
 

--- a/partial/index.js
+++ b/partial/index.js
@@ -52,7 +52,7 @@ PartialGenerator.prototype.files = function files() {
         var partialUrl = this.dir + this.name + '.html';
         //fixed for both slashes windows or unix style directory divider
         partialUrl=partialUrl.substr(4);
-        console.log("url after replace "+partialUrl);
+        
         cgUtils.injectRoute(this.module.file,this.config.get('uirouter'),this.name,this.route,partialUrl,this);
     }
 

--- a/utils.js
+++ b/utils.js
@@ -191,7 +191,7 @@ exports.askForDir = function(type,that,module,ownDir,cb){
     if (!configedDir){
         configedDir = '.';
     }
-		console.log('************adding moddules to path************ '+module.primary)
+		//removing the modules dir in module folder
     var defaultDir;
 		if(module.primary){
 		   defaultDir = path.join(that.dir+'/modules/',configedDir,'/');

--- a/utils.js
+++ b/utils.js
@@ -39,7 +39,6 @@ exports.processTemplates = function(name,dir,type,that,defaultDir,configName,mod
     if (!configName) {
         configName = type + 'Templates';
     }
-
     var templateDirectory = path.join(path.dirname(that.resolved),defaultDir);
     if(that.config.get(configName)){
         templateDirectory = path.join(process.cwd(),that.config.get(configName));
@@ -136,7 +135,7 @@ exports.askForModule = function(type,that,cb){
         cb.bind(that)(mainModule);
         return;
     }
-    
+
     var choices = _.pluck(modules,'name');
     choices.unshift(mainModule.name + ' (Primary Application Module)');
 
@@ -192,7 +191,14 @@ exports.askForDir = function(type,that,module,ownDir,cb){
     if (!configedDir){
         configedDir = '.';
     }
-    var defaultDir = path.join(that.dir+'/modules/',configedDir,'/');
+		console.log('************adding moddules to path************ '+module.primary)
+    var defaultDir;
+		if(module.primary){
+		   defaultDir = path.join(that.dir+'/modules/',configedDir,'/');
+		}else {
+			 defaultDir = path.join(that.dir+'/',configedDir,'/');
+		}
+
     defaultDir = path.relative(process.cwd(),defaultDir);
 
     if (ownDir) {
@@ -258,7 +264,7 @@ exports.askForDir = function(type,that,module,ownDir,cb){
 
     };
 
-    if(that.options.defaultDir===undefined) 
+    if(that.options.defaultDir===undefined)
         that.prompt(dirPrompt,dirPromptCallback);
     else {
         that.dir = that.options.defaultDir;


### PR DESCRIPTION
The gulp script does not work out-of-box. I made the modifications below so that it would work out of box. The changes are tested with the ui-router option selected.
## Problems found
1. html not defined in config
2. Modified JS config to include all JS files other than test-results
   and bower files
3. added missing app.js to karma config
4. added code to app.js template so that $rootScope.$state and
   $rootScope.$stateParams are set when ui-router are selected
5. Modified partial/index.js line 52 to remove '/' concat after this.dir. This was cause double slashes '//' for ui-routers. Not sure if it is the same for angualr-router. (will be testing later)
6. Modified gulpfile.js to add () for cb at the end of test:unit. Otherwise the test:unit throws errors at the end of the test. Test complete but scripts exits with error
7. The template/html2js implementation was not working with karma and gulp serve task (out-of-box) Serve may have worked after running build:dist or html task. The following explains my solution to this problem it might be what it was intended to be but after these modification build,build:dist,test:unit,serve,server:dist all work fine.
   
   Index.html references tmp/templates.js which does not work well with karma unit test. The karma server does not recognize the build directory as a resource. I personally like the philosophy of having all of the original files served on normal gulp serve and then have all the packed/minified sources served on serve:dist. It seems the html only runs on serve:dist anyways. Based on this idea I have made the following modifications.
   - Modified the 'templates' task to uglify the the result template and put it directly into the build/dist/script folder
   - Replaced script reference of tempalte.js the index.html with <!-- templdate-holder --> comment. 
   - Added code in the html task of the gulp script to replace the html comment with the location of the generated script file.
   - Removed template module injection on app.js
   - Added code in the html task to add the template module dependency back to app.js when does
## Remaining Problem

I could not figure out why browswersync stops under the serve:dist task. The server stops as soon as test:unit is done with Karma. For the lack of a better solution I have removed the build:dist dependency so i can at least serve dist after manually running build:dist. I am new to the javascript/node.js scene so i don't know enough about this to fix it. Please let me know how so I can learn.  Another question I have is if watch functionality should be implemented for build:dist.
## Questionable scaffolding (Not sure if this should be accepted)
1. Questionable scaffolding modified in partial/index.js. Running sub generator partial on modules creates file in app/modules/[module-name]/modules/partial/[partial-name] directory. I removed the extra modules so that the files are created in app/modules/[module-name]/partial/[partial-name] directory
## Future effort

Based on reading google’s doc via https://docs.google.com/document/d/1XXMvReO8-Awi1EZXAXS4PzDzdNvV6pGcuaF4
Q9821Es/pub. It seems that this is not a word to word scaffolding implementation. I am thinking about extending this project to utilize the components and sub-section organization by adding component and sub-section sub-generators. I also plan to add -directive -factory -service -controller suffix to all file names that are generated through the sub generators.
